### PR TITLE
feat(issue-3): add collision helpers and unit tests

### DIFF
--- a/src/collision.py
+++ b/src/collision.py
@@ -1,0 +1,35 @@
+from typing import List, Tuple
+
+Position = Tuple[int, int]
+
+def check_wall_collision(pos: Position, width: int, height: int) -> bool:
+    """Return True if pos is outside the playfield (0..width-1, 0..height-1)."""
+    x, y = pos
+    return x < 0 or y < 0 or x >= width or y >= height
+
+def check_self_collision(snake_body: List[Position]) -> bool:
+    """
+    Given a list of positions representing the snake from head to tail,
+    return True if the head collides with any other segment.
+    """
+    if not snake_body:
+        return False
+    head = snake_body[0]
+    return head in snake_body[1:]
+
+def will_collide_next(head: Position, direction: Position, snake_body: List[Position],
+                      width: int, height: int, will_grow: bool = False) -> bool:
+    """
+    Check whether the next head position will collide (wall or self).
+    will_grow: if True, tail does not vacate this turn (e.g. after eating), so check against full body.
+    """
+    next_pos = (head[0] + direction[0], head[1] + direction[1])
+    if check_wall_collision(next_pos, width, height):
+        return True
+
+    # If the snake will grow, tail remains; otherwise tail will vacate and last segment can be ignored.
+    if will_grow:
+        return next_pos in snake_body
+    else:
+        # when not growing, the tail cell is freed, so consider snake_body except last element
+        return next_pos in snake_body[:-1]

--- a/tests/test_collision.py
+++ b/tests/test_collision.py
@@ -1,0 +1,34 @@
+import pytest
+from src.collision import check_wall_collision, check_self_collision, will_collide_next
+
+def test_check_wall_collision_inside():
+    assert not check_wall_collision((2, 3), width=10, height=10)
+
+def test_check_wall_collision_outside():
+    assert check_wall_collision((-1, 0), width=10, height=10)
+    assert check_wall_collision((10, 0), width=10, height=10)
+    assert check_wall_collision((0, 10), width=10, height=10)
+
+def test_check_self_collision_empty():
+    assert not check_self_collision([])
+
+def test_check_self_collision_no_collision():
+    snake = [(2,2), (2,1), (2,0)]
+    assert not check_self_collision(snake)
+
+def test_check_self_collision_hit():
+    snake = [(2,2), (3,2), (2,2), (2,1)]
+    assert check_self_collision(snake)
+
+def test_will_collide_next_wall():
+    assert will_collide_next((9,5), (1,0), [(9,5)], width=10, height=10) is True
+
+def test_will_collide_next_self_no_grow():
+    snake = [(2,2), (2,3), (2,4)]
+    # moving up into the tail cell should be allowed if not growing because tail vacates
+    assert will_collide_next((2,3), (0,1), snake, width=10, height=10, will_grow=False) is False
+
+def test_will_collide_next_self_grow():
+    snake = [(2,2), (2,3), (2,4)]
+    # if growing, moving into the tail is a collision
+    assert will_collide_next((2,3), (0,1), snake, width=10, height=10, will_grow=True) is True


### PR DESCRIPTION
This draft PR adds grid-friendly collision helpers (src/collision.py) and unit tests (tests/test_collision.py) for wall and self-collision logic.

How to run tests

python -m venv .venv
source .venv/bin/activate
pip install pytest
pytest -q
What’s included

src/collision.py — check_wall_collision, check_self_collision, will_collide_next
tests/test_collision.py — unit tests covering wall and self-collision, and will_grow behavior